### PR TITLE
Remove `useCurrentSecond()` reference

### DIFF
--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -15,8 +15,6 @@ import { AnimatedText } from "remotion-animate-text";
 import { AbsoluteFill } from "remotion";
 
 export const Example: React.FC = () => {
-  const second = useCurrentSecond();
-
   const animation = {
     delimiter: "",
     opacity: [0, 1],


### PR DESCRIPTION
Seems like it was left in by mistake